### PR TITLE
Replaced name with SAP Business Accelerator Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There's also an alternative [mini-workshop](https://github.com/SAP-samples/cloud
 
 This CodeJam introduces attendees to `btp`, the CLI for the SAP Business Technology Platform (SAP BTP). Here's the description of the btp CLI from the [official download page](https://tools.hana.ondemand.com/#cloud): "_Use the btp CLI for account administration on SAP BTP. The btp CLI is only available for global accounts on feature set B (for example, SAP BTP Trial accounts)_".
 
-It also introduces attendees to the APIs for SAP BTP, the Core Services for SAP BTP, which, [according to the SAP API Business Hub](https://api.sap.com/package/SAPCloudPlatformCoreServices/rest), allow you to "_manage, build, and extend the core capabilities of SAP BTP._"
+It also introduces attendees to the APIs for SAP BTP, the Core Services for SAP BTP, which, [according to the SAP Business Accelerator Hub](https://hub.sap.com/package/SAPCloudPlatformCoreServices/rest), allow you to "_manage, build, and extend the core capabilities of SAP BTP._"
 
 ## About this CodeJam
 
@@ -67,7 +67,7 @@ Here are a few pointers to resources for further connections and information on 
 * there's a wealth of information on the SAP Help Portal in the [Account Administration Using the SAP BTP Command Line Interface (btp CLI) [Feature Set B]](https://help.sap.com/products/BTP/65de2977205c403bbc107264b8eccf4b/7c6df2db6332419ea7a862191525377c.html?locale=en-US&version=Cloud) topic
 * the playlist [The SAP btp CLI](https://www.youtube.com/playlist?list=PL6RpkC85SLQDXx827kdjKc6HRvdMRZ8P5) on the SAP Developers YouTube channel contains recordings of past live streams on the topic
 * there's a [branch in the SAP Tech Bytes repo](https://github.com/SAP-samples/sap-tech-bytes/tree/2021-09-01-btp-cli) covering some basic aspects of the btp CLI
-* The SAP API Business Hub is the central place for APIs in the SAP world, and there's a specific area for the [Core Services for SAP BTP](https://api.sap.com/package/SAPCloudPlatformCoreServices/rest) API package.
+* The SAP Business Accelerator Hub is the central place for APIs in the SAP world, and there's a specific area for the [Core Services for SAP BTP](https://hub.sap.com/package/SAPCloudPlatformCoreServices/rest) API package.
 
 ## License
 

--- a/exercises/01-installing/README.md
+++ b/exercises/01-installing/README.md
@@ -16,7 +16,7 @@ Why a Dev Space in App Studio, and why a Basic one at that? Well, because it all
 
 The power of the btp CLI comes from multiple angles:
 
-* it gives us comfortable and convenient access to the [BTP APIs](https://api.sap.com/package/SAPCloudPlatformCoreServices/rest)
+* it gives us comfortable and convenient access to the [BTP APIs](https://hub.sap.com/package/SAPCloudPlatformCoreServices/rest)
 * it is a command line tool, meaning it lets us stay within our development flow and can be combined with other developer and devops tools
 * it is scriptable - we can make use of the btp CLI within shell scripts to create whatever automation we need relating to management of resources on BTP
 

--- a/exercises/05-core-services-api-prep/README.md
+++ b/exercises/05-core-services-api-prep/README.md
@@ -1,6 +1,6 @@
 # Exercise 05 - Preparing to call a Core Services API
 
-The btp CLI implementation has a client / server nature. The server component facilitates calls to APIs in the [Core Services for SAP BTP](https://api.sap.com/package/SAPCloudPlatformCoreServices/rest) package. So the btp CLI effectively gives you a comfortable way of consuming those APIs that are specifically designed to let you "manage, build, and extend the core capabilities of SAP BTP".
+The btp CLI implementation has a client / server nature. The server component facilitates calls to APIs in the [Core Services for SAP BTP](https://hub.sap.com/package/SAPCloudPlatformCoreServices/rest) package. So the btp CLI effectively gives you a comfortable way of consuming those APIs that are specifically designed to let you "manage, build, and extend the core capabilities of SAP BTP".
 
 During the course of this and also the next few exercises you'll see that first hand, by observing that the JSON you saw in the previous exercise (emitted from `btp --format json list accounts/available-region`) is effectively the same as the output from a call to the corresponding API endpoint.
 
@@ -14,11 +14,11 @@ Ready?
 
 ## Learning about the API structure, authentication and use
 
-The endpoint in question lives within the [Entitlements Service](https://api.sap.com/api/APIEntitlementsService/overview) API, specifically within the "Regions for Global Account" group. You can see this in the SAP API Business Hub:
+The endpoint in question lives within the [Entitlements Service](https://hub.sap.com/api/APIEntitlementsService/overview) API, specifically within the "Regions for Global Account" group. You can see this in the SAP Business Accelerator Hub:
 
 ![Regions for Global Account endpoint](assets/regions-for-global-account.png)
 
-It's worth pausing a second to think about how APIs are organized on the SAP API Business Hub. There are API packages, APIs, and endpoints that are collected into groups. The hierarchy is as follows, showing where this endpoint is:
+It's worth pausing a second to think about how APIs are organized on the SAP Business Accelerator Hub. There are API packages, APIs, and endpoints that are collected into groups. The hierarchy is as follows, showing where this endpoint is:
 
 ```text
 +-------------+
@@ -96,7 +96,7 @@ We're eventually (in a subsequent exercise) going to make a call to the one endp
 
 The endpoints in the Entitlement Service API are protected by the OAuth 2.0 "Resource Owner Password Credentials" grant type, otherwise known as the "Password" grant type (this grant type is considered legacy, but is still used to protect some resources in this area). See the link to understanding OAuth 2.0 grant types in the [Further reading](#further-reading) section below for more background information.
 
-👉 Head over to the [Entitlements Service API overview](https://api.sap.com/api/APIEntitlementsService/overview) page on the SAP API Business Hub.
+👉 Head over to the [Entitlements Service API overview](https://hub.sap.com/api/APIEntitlementsService/overview) page on the SAP Business Accelerator Hub.
 
 👉 Find and follow the link, under the Documentation heading, to the [Account Administration Using APIs of the SAP Cloud Management Service](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/17b6a171552544a6804f12ea83112a3f.html?locale=en-US) section in the SAP Help Portal, where you'll see something like this:
 

--- a/exercises/09-deleting-resources-with-api/README.md
+++ b/exercises/09-deleting-resources-with-api/README.md
@@ -51,7 +51,7 @@ In a previous exercise, we used the `/entitlements/v1/globalAccountAllowedDataCe
 
 ![The Core Services APIs](assets/core-services-apis.png)
 
-👉 Take a moment to look at the [API reference for the Entitlements Service API](https://api.sap.com/api/APIEntitlementsService/resource), and you'll see that there are three groups of endpoints: "Manage Assigned Entitlements", "Regions for Global Account" and "Job Management":
+👉 Take a moment to look at the [API reference for the Entitlements Service API](https://hub.sap.com/api/APIEntitlementsService/resource), and you'll see that there are three groups of endpoints: "Manage Assigned Entitlements", "Regions for Global Account" and "Job Management":
 
 ![Entitlements Service API endpoint groups](assets/entitlements-endpoint-groups.png)
 
@@ -59,9 +59,9 @@ In a previous exercise, we used the `/entitlements/v1/globalAccountAllowedDataCe
 
 The endpoint we used was within the "Regions for Global Account" group.
 
-This time, we need to find an endpoint that supports operations on directories and subaccounts, and in the [Core Services APIs overview](https://api.sap.com/package/SAPCloudPlatformCoreServices/rest) we can see that the description for the Accounts Service API sounds like what we're looking for: "_Manage the directories and subaccounts in your global account's structure._"
+This time, we need to find an endpoint that supports operations on directories and subaccounts, and in the [Core Services APIs overview](https://hub.sap.com/package/SAPCloudPlatformCoreServices/rest) we can see that the description for the Accounts Service API sounds like what we're looking for: "_Manage the directories and subaccounts in your global account's structure._"
 
-👉 Select the [Accounts Service API](https://api.sap.com/api/APIAccountsService/overview) in the SAP API Business Hub, go to the [API Reference](https://api.sap.com/api/APIAccountsService/resource) section, and take note of the endpoint groups, which are:
+👉 Select the [Accounts Service API](https://hub.sap.com/api/APIAccountsService/overview) in the SAP Business Accelerator Hub, go to the [API Reference](https://hub.sap.com/api/APIAccountsService/resource) section, and take note of the endpoint groups, which are:
 
 * Global Account Operations
 * Directory Operations
@@ -432,7 +432,7 @@ guid=$(btpguid codejam-directory)
 
 ### Using HTTP GET to read the information
 
-Starting cautiously, let's try first to read the directory information, using the HTTP GET method. If you check the Directory Operations group of endpoints for the [Accounts Service API](https://api.sap.com/api/APIAccountsService/resource) you'll see that there's a family of HTTP method + URL path combinations:
+Starting cautiously, let's try first to read the directory information, using the HTTP GET method. If you check the Directory Operations group of endpoints for the [Accounts Service API](https://hub.sap.com/api/APIAccountsService/resource) you'll see that there's a family of HTTP method + URL path combinations:
 
 * `GET    /accounts/v1/directories/{directoryGUID}` (read)
 * `DELETE /accounts/v1/directories/{directoryGUID}` (delete)
@@ -606,7 +606,7 @@ Guess what that relates to? Yes, the deletion activity is asynchronous, and is h
 
 ### Checking the deletion job status
 
-Let's finish this exercise with a final API call, this time to the single endpoint in the [Accounts Service](https://api.sap.com/api/APIAccountsService/resource) Job Management endpoint group:
+Let's finish this exercise with a final API call, this time to the single endpoint in the [Accounts Service](https://hub.sap.com/api/APIAccountsService/resource) Job Management endpoint group:
 
 ```text
 /jobs-management/v1/jobs/{jobInstanceIdOrUniqueId}/status


### PR DESCRIPTION
Replacing SAP API Business Hub with SAP Business Accelerator Hub and updating the domain from api.sap.com to hub.sap.com